### PR TITLE
Python2 codepath is incorrect as check_call() does NOT capture output.

### DIFF
--- a/pyreportjasper/jasperpy.py
+++ b/pyreportjasper/jasperpy.py
@@ -186,7 +186,7 @@ class JasperPy:
             except AttributeError:
                 output = subprocess.check_output(self.command, shell=True)
             except subprocess.CalledProcessError as e:
-                logger.exception(e.output)
+                logger.exception(str(e.output))
                 raise NameError('Your report has an error and couldn '
                                 '\'t be processed!\ Try to output the command '
                                 'using the attribute `command;` and run it '

--- a/pyreportjasper/jasperpy.py
+++ b/pyreportjasper/jasperpy.py
@@ -184,9 +184,9 @@ class JasperPy:
                 output = subprocess.run(
                     self.command, shell=True, check=True).returncode
             except AttributeError:
-                output = subprocess.check_call(self.command, shell=True)
+                output = subprocess.check_output(self.command, shell=True)
             except subprocess.CalledProcessError as e:
-                logger.exception(str(e))
+                logger.exception(e.output)
                 raise NameError('Your report has an error and couldn '
                                 '\'t be processed!\ Try to output the command '
                                 'using the attribute `command;` and run it '


### PR DESCRIPTION
Also, the Python2/3 exception handling path is suboptimal as firstly,
logger.exception() outputs the exception info already (since exc_info is
True by default), and secondly, in both cases it has access to any output
generated which may as well be the msg argument.

(I note that my previous PR#28 didn't address this wider point). For example,
without the fix, the logged output is something like this:

> [2018-07-02 09:14:55,059: ERROR/ForkPoolWorker-15] Command '/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperstarter/bin/jasperstarter --locale en_GB process "/main/srhaque/Innovatieltd/testdjango/paiyroll/report/JasperReports/pre_approval.jrxml" -o "/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/pre_approval" -f pdf -t jsonql --data-file '/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/snapshot.json' --jsonql-query 'employee.*'' returned non-zero exit status 1.
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 188, in execute
>     self.command, shell=True, check=True).returncode
>   File "/usr/lib/python3.6/subprocess.py", line 418, in run
>     output=stdout, stderr=stderr)
> subprocess.CalledProcessError: Command '/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperstarter/bin/jasperstarter --locale en_GB process "/main/srhaque/Innovatieltd/testdjango/paiyroll/report/JasperReports/pre_approval.jrxml" -o "/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/pre_approval" -f pdf -t jsonql --data-file '/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/snapshot.json' --jsonql-query 'employee.*'' returned non-zero exit status 1.
> [2018-07-02 09:14:55,062: ERROR/ForkPoolWorker-15] Unhandled exception
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 188, in execute
>     self.command, shell=True, check=True).returncode
>   File "/usr/lib/python3.6/subprocess.py", line 418, in run
>     output=stdout, stderr=stderr)
> subprocess.CalledProcessError: Command '/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperstarter/bin/jasperstarter --locale en_GB process "/main/srhaque/Innovatieltd/testdjango/paiyroll/report/JasperReports/pre_approval.jrxml" -o "/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/pre_approval" -f pdf -t jsonql --data-file '/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/snapshot.json' --jsonql-query 'employee.*'' returned non-zero exit status 1.
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   ...
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 151, in process
>     return self.execute()
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 193, in execute
>     raise NameError('Your report has an error and couldn '
> NameError: Your report has an error and couldn 't be processed!\ Try to output the command using the attribute `command;` and run it manually in the console!

(Notice how the word "Command" appears 3 times). With the fix the output is the less redundant:

> [2018-07-02 09:06:44,706: ERROR/ForkPoolWorker-2] None
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 188, in execute
>     self.command, shell=True, check=True).returncode
>   File "/usr/lib/python3.6/subprocess.py", line 418, in run
>     output=stdout, stderr=stderr)
> subprocess.CalledProcessError: Command '/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperstarter/bin/jasperstarter --locale en_GB process "/main/srhaque/Innovatieltd/testdjango/paiyroll/report/JasperReports/pre_approval.jrxml" -o "/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/pre_approval" -f pdf -t jsonql --data-file '/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/snapshot.json' --jsonql-query 'employee.*'' returned non-zero exit status 1.
> [2018-07-02 09:06:44,708: ERROR/ForkPoolWorker-2] Unhandled exception
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 188, in execute
>     self.command, shell=True, check=True).returncode
>   File "/usr/lib/python3.6/subprocess.py", line 418, in run
>     output=stdout, stderr=stderr)
> subprocess.CalledProcessError: Command '/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperstarter/bin/jasperstarter --locale en_GB process "/main/srhaque/Innovatieltd/testdjango/paiyroll/report/JasperReports/pre_approval.jrxml" -o "/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/pre_approval" -f pdf -t jsonql --data-file '/tmp/Acme Accountants/Advanced Mechanics/m1/2018-07-28/snapshot.json' --jsonql-query 'employee.*'' returned non-zero exit status 1.
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   ...
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 151, in process
>     return self.execute()
>   File "/usr/local/lib/python3.6/dist-packages/pyreportjasper/jasperpy.py", line 193, in execute
>     raise NameError('Your report has an error and couldn '
> NameError: Your report has an error and couldn 't be processed!\ Try to output the command using the attribute `command;` and run it manually in the console!

(Notice how the first "Command" has been replaced by "None", and would have been
replaced by any output from the command for both Python2/3).